### PR TITLE
Fix SHT4x : prevent implicit double to float conversion and improve readability

### DIFF
--- a/SHT4x.cpp
+++ b/SHT4x.cpp
@@ -91,9 +91,17 @@ bool SHT4x::reset()
 
 float SHT4x::getHumidity()
 {
-  float hum = _rawHumidity * (125.0 / 65535.0) - 6.0;
-  if (hum > 100.0)    hum = 100.0;
-  else if (hum < 0.0) hum = 0.0;
+  constexpr float SCALE = 125.0f / 65535.0f;
+  constexpr float OFFSET = 6.0f;
+
+  float hum = _rawHumidity * SCALE - OFFSET;
+
+  constexpr float HUM_MIN = 0.0f;
+  constexpr float HUM_MAX = 100.0f;
+
+  if (hum > HUM_MAX) hum = HUM_MAX;
+  else if (hum < HUM_MIN) hum = HUM_MIN;
+
   return hum;
 }
 

--- a/SHT4x.cpp
+++ b/SHT4x.cpp
@@ -108,15 +108,19 @@ float SHT4x::getHumidity()
 
 float SHT4x::getTemperature()
 {
-  return _rawTemperature * (175.0 / 65535.0) - 45.0;
-}
+  constexpr float SCALE  = 175.0f / 65535.0f;
+  constexpr float OFFSET = 45.0f;
 
+  return _rawTemperature * SCALE - OFFSET;
+}
 
 float SHT4x::getFahrenheit()
 {
-  return _rawTemperature * (315.0 / 65535.0) - 49.0;
-}
+  constexpr float SCALE  = 315.0f / 65535.0f;
+  constexpr float OFFSET = 49.0f;
 
+  return _rawTemperature * SCALE - OFFSET;
+}
 
 uint16_t SHT4x::getRawHumidity()
 {


### PR DESCRIPTION
**Description**
This PR fixes an implicit conversion issue in SHT4x::getHumidity(), SHT4x::getFahrenheit(), SHT4x::getTemperature()
Previously, constants were written as double literals, causing an unnecessary conversion to float on microcontrollers.

**Changes**
- Replaced magic numbers with constexpr float constants (SCALE, OFFSET, HUM_MIN, HUM_MAX).
- Ensured all literals use the f suffix to avoid degrading conversions.
- Improved readability and maintainability by naming the bounds explicitly.