### PR TITLE
refactor: modernize SHT4x library codebase and update unit tests

### DIFF
--- a/SHT4x.cpp
+++ b/SHT4x.cpp
@@ -339,8 +339,9 @@ bool SHT4x::isHeatCmd(measType measurementType)
     case SHT4x_MEASUREMENT_SHORT_MEDIUM_HEAT:
     case SHT4x_MEASUREMENT_SHORT_LOW_HEAT:
       return true;
+    default:
+      return false;
   }
-  return false;
 }
 
 

--- a/SHT4x.cpp
+++ b/SHT4x.cpp
@@ -14,8 +14,8 @@
 
 
 //  SUPPORTED COMMANDS
-static constexpr uint8_t SHT4x_SOFT_RESET        = 0x94;
-static constexpr uint8_t SHT4x_GET_SERIAL_NUMBER = 0x89;
+constexpr uint8_t SHT4x_SOFT_RESET        = 0x94;
+constexpr uint8_t SHT4x_GET_SERIAL_NUMBER = 0x89;
 
 
 SHT4x::SHT4x(uint8_t address, TwoWire *wire)

--- a/SHT4x.h
+++ b/SHT4x.h
@@ -37,18 +37,18 @@ typedef enum
 } measType;
 
 //  error codes
-constexpr uint8_t SHT4x_OK                            0x00
-constexpr uint8_t SHT4x_ERR_WRITECMD                  0x81
-constexpr uint8_t SHT4x_ERR_READBYTES                 0x82
-constexpr uint8_t SHT4x_ERR_HEATER_OFF                0x83
-constexpr uint8_t SHT4x_ERR_NOT_CONNECT               0x84
-constexpr uint8_t SHT4x_ERR_CRC_TEMP                  0x85
-constexpr uint8_t SHT4x_ERR_CRC_HUM                   0x86
-constexpr uint8_t SHT4x_ERR_CRC_STATUS                0x87
-constexpr uint8_t SHT4x_ERR_HEATER_COOLDOWN           0x88
-constexpr uint8_t SHT4x_ERR_HEATER_ON                 0x89
-constexpr uint8_t SHT4x_ERR_SERIAL_NUMBER_CRC         0x8A
-constexpr uint8_t SHT4x_ERR_INVALID_ADDRESS           0x8B
+constexpr uint8_t SHT4x_OK                   = 0x00;
+constexpr uint8_t SHT4x_ERR_WRITECMD         = 0x81;
+constexpr uint8_t SHT4x_ERR_READBYTES        = 0x82;
+constexpr uint8_t SHT4x_ERR_HEATER_OFF       = 0x83;
+constexpr uint8_t SHT4x_ERR_NOT_CONNECT      = 0x84;
+constexpr uint8_t SHT4x_ERR_CRC_TEMP         = 0x85;
+constexpr uint8_t SHT4x_ERR_CRC_HUM          = 0x86;
+constexpr uint8_t SHT4x_ERR_CRC_STATUS       = 0x87;
+constexpr uint8_t SHT4x_ERR_HEATER_COOLDOWN  = 0x88;
+constexpr uint8_t SHT4x_ERR_HEATER_ON        = 0x89;
+constexpr uint8_t SHT4x_ERR_SERIAL_NUMBER_CRC = 0x8A;
+constexpr uint8_t SHT4x_ERR_INVALID_ADDRESS  = 0x8B;
 
 
 class SHT4x

--- a/SHT4x.h
+++ b/SHT4x.h
@@ -37,18 +37,18 @@ typedef enum
 } measType;
 
 //  error codes
-#define SHT4x_OK                            0x00
-#define SHT4x_ERR_WRITECMD                  0x81
-#define SHT4x_ERR_READBYTES                 0x82
-#define SHT4x_ERR_HEATER_OFF                0x83
-#define SHT4x_ERR_NOT_CONNECT               0x84
-#define SHT4x_ERR_CRC_TEMP                  0x85
-#define SHT4x_ERR_CRC_HUM                   0x86
-#define SHT4x_ERR_CRC_STATUS                0x87
-#define SHT4x_ERR_HEATER_COOLDOWN           0x88
-#define SHT4x_ERR_HEATER_ON                 0x89
-#define SHT4x_ERR_SERIAL_NUMBER_CRC         0x8A
-#define SHT4x_ERR_INVALID_ADDRESS           0x8B
+constexpr uint8_t SHT4x_OK                            0x00
+constexpr uint8_t SHT4x_ERR_WRITECMD                  0x81
+constexpr uint8_t SHT4x_ERR_READBYTES                 0x82
+constexpr uint8_t SHT4x_ERR_HEATER_OFF                0x83
+constexpr uint8_t SHT4x_ERR_NOT_CONNECT               0x84
+constexpr uint8_t SHT4x_ERR_CRC_TEMP                  0x85
+constexpr uint8_t SHT4x_ERR_CRC_HUM                   0x86
+constexpr uint8_t SHT4x_ERR_CRC_STATUS                0x87
+constexpr uint8_t SHT4x_ERR_HEATER_COOLDOWN           0x88
+constexpr uint8_t SHT4x_ERR_HEATER_ON                 0x89
+constexpr uint8_t SHT4x_ERR_SERIAL_NUMBER_CRC         0x8A
+constexpr uint8_t SHT4x_ERR_INVALID_ADDRESS           0x8B
 
 
 class SHT4x

--- a/test/unit_test_001.cpp
+++ b/test/unit_test_001.cpp
@@ -131,7 +131,7 @@ unittest(test_read)
 /*
   TODO - can this be converted to SHT4x call
   start = millis();
-  assertFalse(sht.read(false));
+  assertFalse(sht.read(SHT4x_MEASUREMENT_SLOW, false));
   stop = millis();
   Serial.println(stop - start);
   expect = SHT4x_ERR_READBYTES;
@@ -141,7 +141,7 @@ unittest(test_read)
 /*
   TODO - can this be converted to SHT4x call
   start = millis();
-  assertFalse(sht.read(true));
+  assertFalse(sht.read(SHT4x_MEASUREMENT_SLOW, true));
   stop = millis();
   Serial.println(stop - start);
   expect = SHT4x_ERR_READBYTES;


### PR DESCRIPTION
Switched a bunch of old #define macros to constexpr so the code is safer, cleaner.
I checked the TODOs and I suggested a solution but it has to be tested.

Changes:
- SHT4x.h: replace error code #defines with constexpr uint8_t
- SHT4x.h: replace SHT_DEFAULT_ADDRESS #define with constexpr uint8_t
- SHT4x.cpp: remove redundant static from file-scope constexpr constants
- SHT4x.cpp: add default case to isHeatCmd() switch statement
- unit_test_001.cpp: update test_read blocks to SHT4x API signature
- unit_test_001.cpp: remove obsolete SHT31 heater unittest block